### PR TITLE
Making request identifier an opaque blob of arbitrary length

### DIFF
--- a/draft-thomson-http2-client-certs.md
+++ b/draft-thomson-http2-client-certs.md
@@ -308,11 +308,6 @@ SHOULD treat the receipt of a TLS ClientHello or ServerHello without an
 
 # Indicating Stream Dependency on Certificate Authentication {#frame}
 
-Servers which employ reactive certificate authentication can require that
-authentication on multiple resources.  Because many requests could be awaiting
-responses to the same CertificateRequest, it is insufficient to use the
-stream ID as the `certificate_request_id` or `application_context_id`.
-
 The WAITING_FOR_AUTH frame (0xFRAME-TBD) is sent by servers to indicate that
 processing of a request is blocked pending authentication outside of the HTTP
 channel. The frame includes a request identifier which can be used to correlate
@@ -321,9 +316,9 @@ TLS.
 
 The WAITING_FOR_AUTH frame contains between 1 and 255 octets, which is the
 authentication request identifier.  A client that receives a WAITING_FOR_AUTH of
-any other length MUST treat this as a stream error of type PROTOCOL_ERROR.  The
-request identifier MUST be unique amongst all concurrently outstanding
-authentication requests on the connection.
+any other length MUST treat this as a stream error of type PROTOCOL_ERROR.
+Frames with identical request identifiers refer to the same TLS
+CertificateRequest.
 
 The WAITING_FOR_AUTH frame MUST NOT be sent by clients.  A WAITING_FOR_AUTH
 frame received by a server SHOULD be rejected with a stream error of type

--- a/draft-thomson-http2-client-certs.md
+++ b/draft-thomson-http2-client-certs.md
@@ -313,22 +313,16 @@ authentication on multiple resources.  Because many requests could be awaiting
 responses to the same CertificateRequest, it is insufficient to use the
 stream ID as the `certificate_request_id` or `application_context_id`.
 
-The frame is structured as follows:
-
-~~~
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |X|                   Request Identifier (31)                   |
- +-+-------------------------------------------------------------+
-~~~
-{: #wfa-frame title="The WAITING_FOR_AUTH frame"}
-
 The WAITING_FOR_AUTH frame (0xFRAME-TBD) is sent by servers to indicate that
 processing of a request is blocked pending authentication outside of the HTTP
 channel. The frame includes a request identifier which can be used to correlate
 the stream with challenges for authentication received at other layers, such as
-TLS.  The request identifier MUST be unique amongst all concurrently outstanding
+TLS.
+
+The WAITING_FOR_AUTH frame contains between 1 and 255 octets, which is the
+authentication request identifier.  A client that receives a WAITING_FOR_AUTH of
+any other length MUST treat this as a stream error of type PROTOCOL_ERROR.  The
+request identifier MUST be unique amongst all concurrently outstanding
 authentication requests on the connection.
 
 The WAITING_FOR_AUTH frame MUST NOT be sent by clients.  A WAITING_FOR_AUTH


### PR DESCRIPTION
There is no real need to have this match up with the stream identifier.

I also found a few extra fixes that I will port even if this turns out to be a bad idea.
